### PR TITLE
feat: handle events with tracing data

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ as:
 
 Metrics in a casual java domain are provided by an Event Server to which the tools is connected via a tcp url.
 
-## configuration¶
+## configuration
 ```shell
 Usage: casual-java-event-service-log [-hV] [-d=<logColumnDelimiter>]
                                      --eventServerUrl=<eventServerUrl>
@@ -27,12 +27,12 @@ Usage: casual-java-event-service-log [-hV] [-d=<logColumnDelimiter>]
   -V, --version          Print version information and exit.
 ```
 
-## example¶
+## example
 ```shell
 casual-java-event-service-log --file= logs/service.log
 ```
 
-## log format¶
+## log format gateway protocol 1.0 to 1.2
 Columns are separated by the provided delimiter option (default |)
 
 | column    | format    | description                                                                                                     |
@@ -48,10 +48,35 @@ Columns are separated by the provided delimiter option (default |)
 | code      | string    | outcome of the service call. `OK` if ok, otherwise the reported error from the service                          |
 | order     | character | “order” of the service - sequential or concurrent, denoted by `S` or `C`. `S` reserves a process, `C` does not. |
 
-## example¶
+## example
 
 ```
 some/service|some/parent/service|9585|ff75bcc6ef1b4d1c8ae8d58ee0918f81|3d7519f801e4f65a127d9ac09fa159d:b81a4d8715ad44e8afccb796a02fd77f:42:123|1670372749162496|1670372749162723|0|OK|S
+```
+
+## log format gateway protocol 1.3 to 1.4
+Columns are separated by the provided delimiter option (default |)
+
+| column      | format    | description                                                                                                     |
+|-------------|-----------|-----------------------------------------------------------------------------------------------------------------|
+| service     | string    | name of the invoked service                                                                                     |
+| parent      | string    | name of the parent service, if any.                                                                             |
+| pid         | integer   | process id of the invoked instance                                                                              |
+| execution   | uuid      | unique execution id, like breadcrumbs                                                                           |
+| trid        | xid       | transaction id                                                                                                  |
+| start       | integer   | when the service was invoked, `us` since epoch.                                                                 |
+| end         | integer   | when the service was done, `us` since epoch                                                                     |
+| pending     | integer   | how long caller had to wait for a non busy server, in `us`                                                      |
+| code        | string    | outcome of the service call. `OK` if ok, otherwise the reported error from the service                          |
+| order       | character | “order” of the service - sequential or concurrent, denoted by `S` or `C`. `S` reserves a process, `C` does not. |
+| span        | hex       | 64b OpenTelemetry trace span                                                                                    |
+| parent.span | hex       | 64b OpenTelemetry trace span                                                                                    |
+| code.user   | integer   | user return code from tpreturn                                                                                  |
+
+## example
+
+```
+some/service|some/parent/service|90053|0bd2c4b424e34e2296c25938766eedbf|10459c8a34e6422a9d5f584856db6701:a6f10817cdd94f3987985a8195e8f927:42:90053|1724141674147439|1724141674189439|6000|OK|S|cdb2b8d804d6e205|9bfeec3308a2a9cd|24
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ implementation("se.laz.casual:casual-java-event-service-log:0.0.2:uber-jar")
 
 
 e.g.
-https://repo1.maven.org/maven2/se/laz/casual/casual-java-event-service-log/0.0.1/casual-java-event-service-log-0.0.1-uber-jar.jar
+https://repo1.maven.org/maven2/se/laz/casual/casual-java-event-service-log/0.0.2/casual-java-event-service-log-0.0.2-uber-jar.jar
 
 NB - An uber-jar is only expected to be run without additional jars on the classpath to avoid dependency conflicts. It should not be used as
 a dependency for other code. Rather the normal artifacts for this code base are also published and available with the traditional classifiers: javadoc, sources, jar.
@@ -106,7 +106,7 @@ If you wish to wrap this, you can use the following example shell script.
 casual-java-event-service-log.sh:
 ```shell
 #!/bin/bash
-java -jar ./casual-java-event-service-log-0.0.1.jar $@
+java -jar ./casual-java-event-service-log-0.0.2.jar $@
 ```
 NB - ensure that the jar file location is correct.
 
@@ -199,7 +199,7 @@ ps -ef | grep casual-java-event-service-log | grep "java -jar"
 ```
 Output:
 ```shell
-ck        517785  517784  7 13:37 pts/2    00:00:01 java -jar ./casual-java-event-service-log-0.0.1-runner.jar --eventServerUrl=tcp://192.168.68.117:7774
+ck        517785  517784  7 13:37 pts/2    00:00:01 java -jar ./casual-java-event-service-log-0.0.2-runner.jar --eventServerUrl=tcp://192.168.68.117:7774
 ```
 
 Raise SIGHUP:

--- a/README.md
+++ b/README.md
@@ -77,10 +77,17 @@ Maven Central Coordinates:
 <dependency>
   <groupId>se.laz.casual</groupId>
   <artifactId>casual-java-event-service-log</artifactId>
-  <version>0.0.1</version>
+  <version>0.0.2</version>
   <classifier>uber-jar</classifier>
 </dependency>
 ```
+gradle:
+```gradle
+implementation("se.laz.casual:casual-java-event-service-log:0.0.2:uber-jar")
+```
+
+
+
 e.g.
 https://repo1.maven.org/maven2/se/laz/casual/casual-java-event-service-log/0.0.1/casual-java-event-service-log-0.0.1-uber-jar.jar
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Provides metrics for all service calls that ar invoked within a casual java doma
 Provides same functionality for casual java domains
 as: 
 
-* [service log for gateway protocol 1.0 to 1.2] (https://casualcore.github.io/docs/release/1.6/middleware/event/documentation/service.log.html)
-* [service log for gateway protocol 1.3 to 1.4] (https://casualcore.github.io/docs/release/1.7/middleware/event/documentation/service.log.html)
+* [service log for gateway protocol 1.0 to 1.2](https://casualcore.github.io/docs/release/1.6/middleware/event/documentation/service.log.html)
+* [service log for gateway protocol 1.3 to 1.4](https://casualcore.github.io/docs/release/1.7/middleware/event/documentation/service.log.html)
 
 
 Metrics in a casual java domain are provided by an Event Server to which the tools is connected via a tcp url.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,11 @@
 Provides metrics for all service calls that ar invoked within a casual java domain.
 
 Provides same functionality for casual java domains
-as: http://casual.laz.se/documentation/en/1.6/middleware/event/documentation/service.log.html
+as: 
+
+* [service log for gateway protocol 1.0 to 1.2] (https://casualcore.github.io/docs/release/1.6/middleware/event/documentation/service.log.html)
+* [service log for gateway protocol 1.3 to 1.4] (https://casualcore.github.io/docs/release/1.7/middleware/event/documentation/service.log.html)
+
 
 Metrics in a casual java domain are provided by an Event Server to which the tools is connected via a tcp url.
 

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,14 @@ plugins {
 
 repositories {
     mavenCentral()
-    maven {url 'https://s01.oss.sonatype.org/content/repositories/snapshots' }
+    maven {
+        name = 'Central Portal Snapshots'
+        url = 'https://central.sonatype.com/repository/maven-snapshots/'
+        // Only search this repository for the specific dependency group
+        content {
+            includeGroup("se.laz.casual")
+        }
+    }
     mavenLocal()
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
     id 'io.quarkus'
     id 'jacoco'
     id 'groovy'
-    id("org.sonarqube") version "5.0.0.4638"
+    id "org.sonarqube" version "7.1.0.6387"
 }
 
 repositories {

--- a/src/integration/groovy/se/laz/casual/event/service/log/cli/client/ClientIntTest.groovy
+++ b/src/integration/groovy/se/laz/casual/event/service/log/cli/client/ClientIntTest.groovy
@@ -10,7 +10,9 @@ import se.laz.casual.api.flags.ErrorState
 import se.laz.casual.api.util.time.InstantUtil
 import se.laz.casual.event.Order
 import se.laz.casual.event.ServiceCallEvent
+import se.laz.casual.jca.SpanId
 import se.laz.casual.test.CasualEmbeddedServer
+import spock.lang.Ignore
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -23,13 +25,18 @@ import java.time.format.DateTimeFormatter
  * Currently these tests are manually run to allow testing of different scenarios.
  * They just start an embedded event server and push events.
  * The client needs to be manually run and monitored to check the results.
+ *
+ * Enable it whenever you want to do manual work
  */
+@Ignore
 class ClientIntTest extends Specification
 {
     @Shared CasualEmbeddedServer embeddedServer
 
     @Shared String service1 = "test1"
     @Shared String parent1 = "parent"
+    @Shared String spanId = SpanId.of().asHex()
+    @Shared String parentSpanId = SpanId.of().asHex()
     @Shared int pid1 = 123
     @Shared UUID execution1 = UUID.randomUUID()
     @Shared Xid transactionId1 = Mock(Xid)
@@ -51,6 +58,21 @@ class ClientIntTest extends Specification
             .withCode(code1)
             .withOrder(order1)
             .build()
+
+   @Shared ServiceCallEvent eventWithTracing = ServiceCallEvent.createBuilder(  )
+           .withService(service1)
+           .withParent(parent1)
+           .withPID(pid1)
+           .withExecution(execution1)
+           .withTransactionId(transactionId1)
+           .withPending( pending1 )
+           .withStart( start1 )
+           .withEnd( end1 )
+           .withCode(code1)
+           .withOrder(order1)
+           .withSpanId(spanId)
+           .withParentSpanId(parentSpanId)
+           .build()
 
     @Shared URI eventServerUrl
 
@@ -84,6 +106,7 @@ class ClientIntTest extends Specification
         for( int i=1; i<=1000; i++ )
         {
             embeddedServer.publishEvent( event )
+            embeddedServer.publishEvent( eventWithTracing )
             Thread.sleep( 10 )
         }
         Instant end = Instant.now()
@@ -105,6 +128,7 @@ class ClientIntTest extends Specification
         for( int i=1; i<=2000; i++ )
         {
             embeddedServer.publishEvent( event )
+            embeddedServer.publishEvent( eventWithTracing )
             Thread.sleep( 5000 )
             if( i % 10 == 0 )
             {
@@ -134,7 +158,7 @@ class ClientIntTest extends Specification
         for( int i=1; i<=100000; i++ )
         {
             embeddedServer.publishEvent( event )
-            //Thread.sleep( 1 )
+            embeddedServer.publishEvent( eventWithTracing )
         }
         Instant end = Instant.now()
         System.out.println( "Duration" + InstantUtil.toDurationMicro( start, end ) )

--- a/src/integration/groovy/se/laz/casual/event/service/log/cli/client/ClientIntTest.groovy
+++ b/src/integration/groovy/se/laz/casual/event/service/log/cli/client/ClientIntTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, The casual project. All rights reserved.
+ * Copyright (c) 2024 - 2026, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */

--- a/src/integration/groovy/se/laz/casual/event/service/log/cli/client/IntTest.groovy
+++ b/src/integration/groovy/se/laz/casual/event/service/log/cli/client/IntTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, The casual project. All rights reserved.
+ * Copyright (c) 2026, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */
@@ -131,7 +131,7 @@ class IntTest extends Specification
         embeddedServer.publishEvent( event )
         embeddedServer.publishEvent( eventWithTracing )
 
-        // poll until events are written to file
+        // poll until both events have been written to file
         def lines = []
         while( lines.size(  ) < 2)
         {

--- a/src/integration/groovy/se/laz/casual/event/service/log/cli/client/IntTest.groovy
+++ b/src/integration/groovy/se/laz/casual/event/service/log/cli/client/IntTest.groovy
@@ -119,10 +119,7 @@ class IntTest extends Specification
     {
         storeProcessor?.stop(  )
         client?.close(  )
-        if( embeddedServer != null )
-        {
-            embeddedServer.shutdown(  )
-        }
+        embeddedServer?.shutdown(  )
     }
 
     def "Events are published and written to file with correct content"()
@@ -145,12 +142,10 @@ class IntTest extends Specification
         and: 'event without tracing data matches expected format'
         def expectedEvent = ServiceCallEventFormatter.format( event, delimiter )
         lines[0] == expectedEvent
-        println("line 1: ${lines[0]}")
 
         and: 'event with tracing data matches expected format'
         def expectedEventWithTracing = ServiceCallEventFormatter.format( eventWithTracing, delimiter )
         lines[1] == expectedEventWithTracing
-        println("line 2: ${lines[1]}")
     }
 
 }

--- a/src/integration/groovy/se/laz/casual/event/service/log/cli/client/IntTest.groovy
+++ b/src/integration/groovy/se/laz/casual/event/service/log/cli/client/IntTest.groovy
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2024, The casual project. All rights reserved.
+ *
+ * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
+ */
+
+package se.laz.casual.event.service.log.cli.client
+
+import se.laz.casual.api.flags.ErrorState
+import se.laz.casual.event.Order
+import se.laz.casual.event.ServiceCallEvent
+import se.laz.casual.event.ServiceCallEventStoreFactory
+import se.laz.casual.event.service.log.cli.log.EventHandler
+import se.laz.casual.event.service.log.cli.log.ServiceCallEventFormatter
+import se.laz.casual.event.service.log.cli.log.ServiceLogger
+import se.laz.casual.event.service.log.cli.runner.EventStoreProcessor
+import se.laz.casual.event.service.log.cli.runner.TestEventServiceLogParams
+import se.laz.casual.jca.SpanId
+import se.laz.casual.test.CasualEmbeddedServer
+import spock.lang.Shared
+import spock.lang.Specification
+
+import javax.transaction.xa.Xid
+import java.time.Instant
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+
+/**
+ * verifies that events on the wire as JSON
+ * are handled correctly, both for versions with and without tracing information
+ */
+class IntTest extends Specification
+{
+    @Shared CasualEmbeddedServer embeddedServer
+    @Shared String service1 = "a nifty service"
+    @Shared String parent1 = "bob"
+    @Shared String spanId = SpanId.of().asHex()
+    @Shared String parentSpanId = SpanId.of().asHex()
+    @Shared long userDefinedCode = 42L
+    @Shared int pid1 = 123
+    @Shared UUID execution1 = UUID.randomUUID()
+    @Shared Xid transactionId1 = Mock(Xid){
+       getGlobalTransactionId() >> {
+          'gtrid' as byte[]
+       }
+       getBranchQualifier() >> {
+          'btrid' as byte[]
+       }
+       getFormatId() >> {
+          42
+       }
+    }
+    @Shared long pending1 = 5L
+    @Shared ErrorState code1 = ErrorState.OK
+    @Shared Order order1 = Order.CONCURRENT
+
+    @Shared Instant start1 = ZonedDateTime.parse( "2024-04-15T12:34:56.123456Z", DateTimeFormatter.ISO_ZONED_DATE_TIME).toInstant()
+    @Shared Instant end1 = ZonedDateTime.parse( "2024-04-15T12:35:04.123456Z", DateTimeFormatter.ISO_ZONED_DATE_TIME).toInstant()
+    @Shared ServiceCallEvent event = ServiceCallEvent.createBuilder(  )
+            .withService(service1)
+            .withParent(parent1)
+            .withPID(pid1)
+            .withExecution(execution1)
+            .withTransactionId(transactionId1)
+            .withPending( pending1 )
+            .withStart( start1 )
+            .withEnd( end1 )
+            .withCode(code1)
+            .withOrder(order1)
+            .build()
+
+   @Shared ServiceCallEvent eventWithTracing = ServiceCallEvent.createBuilder(  )
+           .withService(service1)
+           .withParent(parent1)
+           .withPID(pid1)
+           .withExecution(execution1)
+           .withTransactionId(transactionId1)
+           .withPending( pending1 )
+           .withStart( start1 )
+           .withEnd( end1 )
+           .withCode(code1)
+           .withOrder(order1)
+           .withSpanId(spanId)
+           .withParentSpanId(parentSpanId)
+           .withUserCode(userDefinedCode)
+           .build()
+
+    @Shared URI eventServerUrl
+    @Shared File tempFile
+    @Shared String delimiter = "|"
+    @Shared EventStoreProcessor storeProcessor
+    @Shared Client client
+
+    def setupSpec()
+    {
+        embeddedServer = CasualEmbeddedServer.newBuilder()
+                .eventServerEnabled( true )
+                .build(  )
+        embeddedServer.start(  )
+
+        eventServerUrl = URI.create("tcp://localhost:" + embeddedServer.getEventServerPort(  ).get() )
+
+        tempFile = File.createTempFile( "test-events", ".log" )
+        tempFile.deleteOnExit(  )
+
+        def params = new TestEventServiceLogParams( eventServerUrl, tempFile, delimiter, null, null )
+        def store = ServiceCallEventStoreFactory.getStore( UUID.randomUUID(  ) )
+        def logger = ServiceLogger.newBuilder(  ).eventServiceLogParams( params ).build(  )
+        def handler = EventHandler.newBuilder(  ).serviceLogger( logger ).build(  )
+        storeProcessor = new EventStoreProcessor( store, handler )
+
+        client = Client.newBuilder()
+                .eventServerUrl( eventServerUrl )
+                .eventObserver( store::put )
+                .build()
+    }
+
+    def cleanupSpec()
+    {
+        storeProcessor?.stop(  )
+        client?.close(  )
+        if( embeddedServer != null )
+        {
+            embeddedServer.shutdown(  )
+        }
+    }
+
+    def "Events are published and written to file with correct content"()
+    {
+        when:
+        embeddedServer.publishEvent( event )
+        embeddedServer.publishEvent( eventWithTracing )
+
+        // poll until events are written to file
+        def lines = []
+        while( lines.size(  ) < 2)
+        {
+            Thread.sleep( 100 )
+            lines = tempFile.readLines(  )
+        }
+
+        then:
+        lines.size(  ) == 2
+
+        and: 'event without tracing data matches expected format'
+        def expectedEvent = ServiceCallEventFormatter.format( event, delimiter )
+        lines[0] == expectedEvent
+        println("line 1: ${lines[0]}")
+
+        and: 'event with tracing data matches expected format'
+        def expectedEventWithTracing = ServiceCallEventFormatter.format( eventWithTracing, delimiter )
+        lines[1] == expectedEventWithTracing
+        println("line 2: ${lines[1]}")
+    }
+
+}

--- a/src/main/java/se/laz/casual/event/service/log/cli/client/Client.java
+++ b/src/main/java/se/laz/casual/event/service/log/cli/client/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, The casual project. All rights reserved.
+ * Copyright (c) 2024 - 2026, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */

--- a/src/main/java/se/laz/casual/event/service/log/cli/client/Client.java
+++ b/src/main/java/se/laz/casual/event/service/log/cli/client/Client.java
@@ -83,7 +83,7 @@ public class Client
         private EventClient eventClient;
         private URI eventServerUrl;
         private EventObserver eventObserver;
-        private CompletableFuture<Boolean> disconnected = new CompletableFuture<>();
+        private final CompletableFuture<Boolean> disconnected = new CompletableFuture<>();
 
         private Builder()
         {

--- a/src/main/java/se/laz/casual/event/service/log/cli/log/ServiceCallEventFormatter.java
+++ b/src/main/java/se/laz/casual/event/service/log/cli/log/ServiceCallEventFormatter.java
@@ -51,7 +51,9 @@ public class ServiceCallEventFormatter
         appendColumn( event.getPending() );
         appendColumn( event.getCode() );
         appendColumn( event.getOrder() );
-
+        event.getSpan().ifPresent(this::appendColumn);
+        event.getParentSpan().ifPresent(this::appendColumn);
+        event.getUserDefinedCode().ifPresent(this::appendColumn);
         return String.join( delimiter, columnValues );
     }
     private void appendColumn( long data )

--- a/src/main/java/se/laz/casual/event/service/log/cli/log/ServiceCallEventFormatter.java
+++ b/src/main/java/se/laz/casual/event/service/log/cli/log/ServiceCallEventFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, The casual project. All rights reserved.
+ * Copyright (c) 2024 - 2026, The casual project. All rights reserved.
  *
  * This software is licensed under the MIT license, https://opensource.org/licenses/MIT
  */

--- a/versions.gradle
+++ b/versions.gradle
@@ -11,8 +11,8 @@ version '0.0.1'
 def quarkusPlatformGroupId = 'io.quarkus.platform'
 def quarkusPlatformArtifactId = 'quarkus-bom'
 def quarkusPlatformVersion = '3.10.0'
-def casualVersion = '3.2.41'
-def gson_version = '2.10.1'
+def casualVersion = '3.4.2'
+def gson_version = '2.13.2'
 
 ext.libs = [
         quarkus_platform: "${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}",

--- a/versions.gradle
+++ b/versions.gradle
@@ -6,7 +6,7 @@
 
 // casual-java group and version
 group 'se.laz.casual'
-version '0.0.1'
+version '0.0.2'
 
 def quarkusPlatformGroupId = 'io.quarkus.platform'
 def quarkusPlatformArtifactId = 'quarkus-bom'

--- a/versions.gradle
+++ b/versions.gradle
@@ -12,7 +12,7 @@ def quarkusPlatformGroupId = 'io.quarkus.platform'
 def quarkusPlatformArtifactId = 'quarkus-bom'
 def quarkusPlatformVersion = '3.10.0'
 def casualVersion = '3.4.2'
-def gson_version = '2.13.2'
+def gson_version = '2.10.1'
 
 ext.libs = [
         quarkus_platform: "${quarkusPlatformGroupId}:${quarkusPlatformArtifactId}:${quarkusPlatformVersion}",


### PR DESCRIPTION
Can now also handle events with tracing data.
A real integration test has been added that uses the embedded server and the event service log's client with data going on the wire as JSON, writing to file and verifying the actual output.
